### PR TITLE
WEBDEV-7568 Add new display mode exposing prompt/votes immediately

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -62,6 +62,15 @@ export class AppRoot extends LitElement {
         deserunt id in cillum pariatur.
       </p>
 
+      <feature-feedback
+        displayMode="vote-prompt"
+        .recaptchaManager=${this.recaptchaManager}
+        .featureFeedbackService=${this.featureFeedbackService}
+        .resizeObserver=${this.resizeObserver}
+        .featureIdentifier=${'demo-feature'}
+      >
+      </feature-feedback>
+
       <p>
         Ea labore laborum proident eiusmod nostrud non do nisi sunt do consequat
         exercitation. Incididunt cillum cupidatat laboris eu enim dolor magna et

--- a/src/feature-feedback.ts
+++ b/src/feature-feedback.ts
@@ -255,7 +255,10 @@ export class FeatureFeedback
    */
   private get votePromptDisplay(): TemplateResult {
     return html`
-      <form @submit=${this.submit}></form>
+      <form
+        @submit=${this.submit}
+        ?disabled=${this.processing || this.voteSubmitted}
+      >
         <div class="prompt">
           <span class="prompt-text">${this.prompt}</span>
           <label
@@ -315,7 +318,11 @@ export class FeatureFeedback
           id="popup"
           style="left: ${this.popupTopX}px; top: ${this.popupTopY}px"
         >
-          <form @submit=${this.submit} id="form" ?disabled=${this.processing}>
+          <form
+            @submit=${this.submit}
+            id="form"
+            ?disabled=${this.processing || this.voteSubmitted}
+          >
             <div class="prompt">
               <div class="prompt-text">${this.prompt}</div>
               <label
@@ -761,6 +768,10 @@ export class FeatureFeedback
 
       .vote-button.error {
         box-shadow: 0 0 4px red;
+      }
+
+      form[disabled] .vote-button.unselected {
+        cursor: not-allowed;
       }
 
       #comment-button {

--- a/src/feature-feedback.ts
+++ b/src/feature-feedback.ts
@@ -294,7 +294,7 @@ export class FeatureFeedback
             />
             ${thumbsDown}
           </label>
-          <button id="comment-button" @click=${this.showPopup}>
+          <button id="comment-button" type="button" @click=${this.showPopup}>
             Leave a comment
           </button>
         </div>

--- a/src/feature-feedback.ts
+++ b/src/feature-feedback.ts
@@ -18,7 +18,7 @@ import type {
   RecaptchaWidgetInterface,
 } from '@internetarchive/recaptcha-manager';
 import type { FeatureFeedbackServiceInterface } from './feature-feedback-service';
-import type { Vote } from './models';
+import type { FeatureFeedbackDisplayMode, Vote } from './models';
 
 import { thumbsUp } from './img/thumb-up';
 import { thumbsDown } from './img/thumb-down';
@@ -34,6 +34,17 @@ export class FeatureFeedback
 
   @property({ type: String }) buttonText = 'Beta';
 
+  /**
+   * - `button` renders a single button with the provided button text (or default 'Beta').
+   * Clicking the button opens the popup.
+   * - `vote-prompt` renders the provided prompt text alongside two up/down vote buttons and
+   * a "Leave a comment" button.
+   * Clicking either vote button immediately submits feedback without a comment.
+   * Clicking the comment button instead opens the popup.
+   */
+  @property({ type: String }) displayMode: FeatureFeedbackDisplayMode =
+    'button';
+
   @property({ type: Object }) recaptchaManager?: RecaptchaManagerInterface;
 
   @property({ type: Object }) resizeObserver?: SharedResizeObserverInterface;
@@ -42,10 +53,6 @@ export class FeatureFeedback
 
   @property({ type: Object })
   featureFeedbackService?: FeatureFeedbackServiceInterface;
-
-  @query('#beta-button') private betaButton!: HTMLButtonElement;
-
-  @query('#popup') private popup!: HTMLDivElement;
 
   @state() private isOpen = false;
 
@@ -65,6 +72,10 @@ export class FeatureFeedback
 
   @state() private recaptchaWidget?: RecaptchaWidgetInterface;
 
+  @query('#container') private container!: HTMLDivElement;
+
+  @query('#popup') private popup!: HTMLDivElement;
+
   @query('#comments') private comments!: HTMLTextAreaElement;
 
   private boundEscapeListener!: (this: Document, ev: KeyboardEvent) => any;
@@ -73,28 +84,11 @@ export class FeatureFeedback
 
   render() {
     return html`
-      <button
-        id="beta-button"
-        @click=${this.showPopup}
-        tabindex="0"
-        ?disabled=${this.disabled}
-      >
-        <span id="button-text">${this.buttonText}</span>
-        <span
-          class="beta-button-thumb upvote-button ${this.voteSubmitted
-            ? this.upvoteButtonClass
-            : ''}"
-          >${thumbsUp}</span
-        >
-        <span
-          class="beta-button-thumb downvote-button ${this.voteSubmitted
-            ? this.downvoteButtonClass
-            : ''}"
-          id="beta-button-thumb-down"
-          >${thumbsDown}</span
-        >
-      </button>
-      ${this.popupTemplate}
+      <div id="container">
+        ${this.displayMode === 'vote-prompt'
+          ? this.votePromptDisplay
+          : this.singleButtonDisplay}
+      </div>
     `;
   }
 
@@ -163,9 +157,8 @@ export class FeatureFeedback
   }
 
   private async showPopup() {
-    if (this.voteSubmitted) return;
+    if (this.voteSubmitted && this.displayMode === 'button') return;
 
-    this.resetState();
     this.setupResizeObserver();
     this.setupScrollObserver();
     this.setupEscapeListener();
@@ -182,32 +175,32 @@ export class FeatureFeedback
   }
 
   private positionPopup() {
-    const betaRect = this.betaButton.getBoundingClientRect();
+    const containerRect = this.container.getBoundingClientRect();
     const popupRect = this.popup.getBoundingClientRect();
     const windowWidth = window.innerWidth;
     const windowHeight = window.innerHeight;
     const windowCenterX = windowWidth / 2;
     const windowCenterY = windowHeight / 2;
-    if (betaRect.left < windowCenterX) {
-      this.popupTopX = betaRect.right - 20;
+    if (containerRect.left < windowCenterX) {
+      this.popupTopX = containerRect.right - 20;
     } else {
-      this.popupTopX = betaRect.left + 20 - popupRect.width;
+      this.popupTopX = containerRect.left + 20 - popupRect.width;
     }
     this.popupTopX = Math.max(0, this.popupTopX);
     if (this.popupTopX + popupRect.width > windowWidth) {
       this.popupTopX = windowWidth - popupRect.width;
     }
 
-    if (betaRect.top < windowCenterY) {
-      this.popupTopY = betaRect.bottom - 10;
+    if (containerRect.top < windowCenterY) {
+      this.popupTopY = containerRect.bottom - 10;
     } else {
-      this.popupTopY = betaRect.top + 10 - popupRect.height;
+      this.popupTopY = containerRect.top + 10 - popupRect.height;
     }
   }
 
   private handleEscape(e: KeyboardEvent) {
     if (e.key === 'Escape') {
-      this.closePopup();
+      this.cancel(e);
     }
   }
 
@@ -227,6 +220,89 @@ export class FeatureFeedback
     document.removeEventListener('scroll', this.boundScrollListener);
   }
 
+  /**
+   * Template for the feedback widget in the `button` display mode.
+   */
+  private get singleButtonDisplay(): TemplateResult {
+    return html`
+      <button
+        id="beta-button"
+        @click=${this.showPopup}
+        tabindex="0"
+        ?disabled=${this.disabled}
+      >
+        <span id="button-text">${this.buttonText}</span>
+        <span
+          class="beta-button-thumb upvote-button ${this.voteSubmitted
+            ? this.upvoteButtonClass
+            : ''}"
+          >${thumbsUp}</span
+        >
+        <span
+          class="beta-button-thumb downvote-button ${this.voteSubmitted
+            ? this.downvoteButtonClass
+            : ''}"
+          id="beta-button-thumb-down"
+          >${thumbsDown}</span
+        >
+      </button>
+      ${this.popupTemplate}
+    `;
+  }
+
+  /**
+   * Template for the feedback widget in the `vote-prompt` display mode.
+   */
+  private get votePromptDisplay(): TemplateResult {
+    return html`
+      <form @submit=${this.submit}></form>
+        <div class="prompt">
+          <span class="prompt-text">${this.prompt}</span>
+          <label
+            tabindex="0"
+            role="button"
+            aria-pressed=${this.upvoteSelected}
+            @keyup=${this.upvoteKeypressed}
+            class="vote-button upvote-button ${this.upvoteButtonClass}"
+          >
+            <input
+              type="radio"
+              name="vote"
+              value="up"
+              @click=${this.upvoteButtonSelected}
+              ?checked=${this.upvoteSelected}
+            />
+            ${thumbsUp}
+          </label>
+
+          <label
+            tabindex="0"
+            role="button"
+            aria-pressed=${this.downvoteSelected}
+            @keyup=${this.downvoteKeypressed}
+            class="vote-button downvote-button ${this.downvoteButtonClass}"
+          >
+            <input
+              type="radio"
+              name="vote"
+              value="down"
+              @click=${this.downvoteButtonSelected}
+              ?checked=${this.downvoteSelected}
+            />
+            ${thumbsDown}
+          </label>
+          <button id="comment-button" @click=${this.showPopup}>
+            Leave a comment
+          </button>
+        </div>
+      </form>
+      ${this.popupTemplate}
+    `;
+  }
+
+  /**
+   * Template for the popup menu that appears when the feedback button(s) are clicked.
+   */
   private get popupTemplate() {
     return html`
       <div
@@ -240,12 +316,12 @@ export class FeatureFeedback
           style="left: ${this.popupTopX}px; top: ${this.popupTopY}px"
         >
           <form @submit=${this.submit} id="form" ?disabled=${this.processing}>
-            <div id="prompt">
-              <div id="prompt-text">${this.prompt}</div>
+            <div class="prompt">
+              <div class="prompt-text">${this.prompt}</div>
               <label
                 tabindex="0"
                 role="button"
-                ?aria-pressed=${this.upvoteSelected}
+                aria-pressed=${this.upvoteSelected}
                 @click=${this.upvoteButtonSelected}
                 @keyup=${this.upvoteKeypressed}
                 class="vote-button upvote-button ${this
@@ -264,7 +340,7 @@ export class FeatureFeedback
               <label
                 tabindex="0"
                 role="button"
-                ?aria-pressed=${this.downvoteSelected}
+                aria-pressed=${this.downvoteSelected}
                 @click=${this.downvoteButtonSelected}
                 @keyup=${this.downvoteKeypressed}
                 class="vote-button downvote-button ${this
@@ -335,11 +411,23 @@ export class FeatureFeedback
   }
 
   private upvoteButtonSelected() {
+    if (this.processing || this.voteSubmitted) return;
     this.vote = this.vote === 'up' ? undefined : 'up';
+    this.handleButtonSelection();
   }
 
   private downvoteButtonSelected() {
+    if (this.processing || this.voteSubmitted) return;
     this.vote = this.vote === 'down' ? undefined : 'down';
+    this.handleButtonSelection();
+  }
+
+  private async handleButtonSelection() {
+    // If a button is pressed _outside_ the popup, it should take effect immediately
+    if (!this.isOpen) {
+      await this.setupRecaptcha();
+      this.submit();
+    }
   }
 
   private get chooseVoteErrorClass(): string {
@@ -371,17 +459,17 @@ export class FeatureFeedback
   private backgroundClicked(e: MouseEvent) {
     if (!(e.target instanceof Node)) return;
     if (this.popup?.contains(e.target)) return;
-    this.closePopup();
+    this.cancel(e);
   }
 
   private cancel(e: Event) {
     e.preventDefault();
-    this.vote = undefined;
     this.closePopup();
+    if (!this.voteSubmitted) this.resetState();
   }
 
-  private async submit(e: Event) {
-    e.preventDefault();
+  private async submit(e?: Event) {
+    e?.preventDefault();
 
     if (!this.vote) {
       this.voteNeedsChoosing = true;
@@ -401,6 +489,7 @@ export class FeatureFeedback
       throw new Error('recaptchaWidget is required');
     }
 
+    const popupWasOpen = this.isOpen;
     this.processing = true;
 
     try {
@@ -414,7 +503,7 @@ export class FeatureFeedback
 
       if (response.success) {
         this.voteSubmitted = true;
-        this.closePopup();
+        if (popupWasOpen) this.closePopup();
       } else {
         this.error = html`There was an error submitting your feedback.`;
       }
@@ -446,7 +535,10 @@ export class FeatureFeedback
     const popupBackgroundColor = css`var(--featureFeedbackPopupBackgroundColor, #F5F5F7)`;
 
     const promptFontWeight = css`var(--featureFeedbackPromptFontWeight, bold)`;
-    const promptFontSize = css`var(--featureFeedbackPromptFontSize, 14px)`;
+    const promptFontSize = css`var(--featureFeedbackPromptFontSize, 1.4rem)`;
+
+    const commentButtonFontWeight = css`var(--featureFeedbackCommentButtonFontWeight, normal)`;
+    const commentButtonFontSize = css`var(--featureFeedbackCommentButtonFontWeight, 1.4rem)`;
 
     const defaultColor = css`var(--defaultColor, ${darkGrayColor});`;
     const defaultColorSvgFilter = css`var(--defaultColorSvgFilter, ${darkGrayColorSvgFilter});`;
@@ -461,6 +553,10 @@ export class FeatureFeedback
     const unselectedColorSvgFilter = css`var(--unselectedColorSvgFilter, invert(100%) sepia(0%) saturate(107%) hue-rotate(138deg) brightness(89%) contrast(77%));`;
 
     return css`
+      #container {
+        display: inline-block;
+      }
+
       #beta-button {
         font-size: 12px;
         font-weight: bold;
@@ -549,19 +645,19 @@ export class FeatureFeedback
         margin-bottom: 0;
       }
 
-      #prompt {
+      .prompt {
         display: flex;
         align-items: center;
         font-size: ${promptFontSize};
         font-weight: ${promptFontWeight};
       }
 
-      #prompt > label {
+      .prompt > label {
         flex: none;
         cursor: pointer;
       }
 
-      #prompt-text {
+      .prompt-text {
         text-align: left;
       }
 
@@ -665,6 +761,16 @@ export class FeatureFeedback
 
       .vote-button.error {
         box-shadow: 0 0 4px red;
+      }
+
+      #comment-button {
+        color: var(--ia-theme-link-color, #4b64ff);
+        font-weight: ${commentButtonFontWeight};
+        font-size: ${commentButtonFontSize};
+      }
+      #comment-button:not([disabled]):hover,
+      #comment-button:not([disabled]):active {
+        text-decoration: underline;
       }
     `;
   }

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,1 +1,3 @@
 export type Vote = 'up' | 'down';
+
+export type FeatureFeedbackDisplayMode = 'button' | 'vote-prompt';

--- a/test/feature-feedback.test.ts
+++ b/test/feature-feedback.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-duplicates */
-import { html, fixture, expect } from '@open-wc/testing';
+import { html, fixture, expect, nextFrame } from '@open-wc/testing';
 import { FeatureFeedback } from '../src/feature-feedback';
 import '../src/feature-feedback';
 import { MockFeatureFeedbackService } from './mocks/mock-feature-feedback-service';
@@ -141,5 +141,78 @@ describe('FeatureFeedback', () => {
       'label.vote-button.upvote-button'
     ) as HTMLLabelElement;
     expect(upvoteButton.classList.contains('error')).to.be.true;
+  });
+
+  it('in vote-prompt mode, shows the prompt with vote/comment buttons', async () => {
+    const el = (await fixture(html`
+      <feature-feedback
+        displayMode="vote-prompt"
+        prompt="foobar"
+      ></feature-feedback>
+    `)) as FeatureFeedback;
+
+    const promptContainer = el.shadowRoot!.querySelector('.prompt');
+    const promptText = promptContainer!.querySelector(
+      '.prompt-text'
+    ) as HTMLSpanElement;
+    expect(promptText.innerText).to.equal('foobar');
+
+    const voteButtons = promptContainer!.querySelectorAll('.vote-button');
+    expect(voteButtons.length).to.equal(2);
+
+    const commentButton = promptContainer!.querySelector(
+      '#comment-button'
+    ) as HTMLButtonElement;
+    expect(commentButton).to.exist;
+  });
+
+  it('in vote-prompt mode, submits feedback when clicking a vote button outside the popup', async () => {
+    const service = new MockFeatureFeedbackService();
+    const recaptchaManager = new MockRecaptchaManager();
+
+    const el = (await fixture(html`
+      <feature-feedback
+        displayMode="vote-prompt"
+        featureIdentifier="foo-feature"
+        .featureFeedbackService=${service}
+        .recaptchaManager=${recaptchaManager}
+      ></feature-feedback>
+    `)) as FeatureFeedback;
+
+    const upvoteButton = el.shadowRoot!.querySelector(
+      ':not(#popup) .upvote-button'
+    ) as HTMLLabelElement;
+    upvoteButton.click();
+
+    await el.updateComplete;
+    await nextFrame();
+    expect(service.submissionOptions).to.deep.equal({
+      featureIdentifier: 'foo-feature',
+      vote: 'up',
+      comments: '',
+      recaptchaToken: 'boop',
+    });
+  });
+
+  it('in vote-prompt mode, shows the popup when "Leave a comment" is clicked', async () => {
+    const el = (await fixture(html`
+      <feature-feedback displayMode="vote-prompt"></feature-feedback>
+    `)) as FeatureFeedback;
+
+    const commentButton = el.shadowRoot!.querySelector(
+      '#comment-button'
+    ) as HTMLButtonElement;
+    const background = el.shadowRoot!.querySelector(
+      '#popup-background'
+    ) as HTMLDivElement;
+
+    const classes = background.classList;
+    expect(classes.contains('closed')).to.be.true;
+    expect(classes.contains('open')).to.be.false;
+
+    commentButton.click();
+    await el.updateComplete;
+    expect(classes.contains('open')).to.be.true;
+    expect(classes.contains('closed')).to.be.false;
   });
 });


### PR DESCRIPTION
Adds a second display mode to the feedback component, which exposes the full prompt text and voting buttons outside the popup. In this mode, the voting buttons immediately submit feedback, allowing for minimal friction in the interaction for those who just want to indicate a sentiment. A "Leave a comment" button appears beside the voting buttons to open the popup for those who wish to provide more details.