### PR TITLE
Fix codecov build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: latest
 
     - name: Install dependencies
       run: yarn install
@@ -22,5 +22,6 @@ jobs:
     - name: Run tests
       run: yarn run test
 
-    - name: Upload reports
-      run: npx codecov
+    - uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Our builds are failing due to an error in an outdated codecov action. This PR upgrades our CI config to enable a newer version of that action that can successfully upload coverage reports to codecov.