### PR TITLE
Add CSS var to style beta button background

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -92,6 +92,28 @@ export class AppRoot extends LitElement {
       </feature-feedback>
 
       <p>
+        Et esse sunt officia velit. Excepteur non sint irure non consectetur
+        labore deserunt aliqua elit. Commodo cupidatat tempor minim
+        reprehenderit pariatur aliqua fugiat fugiat Lorem anim est nisi culpa
+        ea. Sint fugiat aute reprehenderit ullamco magna ullamco exercitation ea
+        sunt reprehenderit. Incididunt commodo sunt velit consequat elit amet ea
+        aute et tempor. Amet qui ut nostrud ullamco labore tempor.
+      </p>
+
+      With custom styling:
+      <feature-feedback
+        style="
+          --featureFeedbackBetaButtonBackground: linear-gradient(to bottom right, #2fffff 0%, #90ff90 100%);
+          --featureFeedbackPopupBackgroundColor: #ddddff;
+        "
+        .recaptchaManager=${this.recaptchaManager}
+        .featureFeedbackService=${this.featureFeedbackService}
+        .resizeObserver=${this.resizeObserver}
+        .featureIdentifier=${'demo-feature'}
+      >
+      </feature-feedback>
+
+      <p>
         Nulla reprehenderit et consequat cupidatat reprehenderit pariatur anim
         aute nulla. Sunt labore mollit nulla irure laboris sunt occaecat. Ea
         velit laboris in dolore do nulla Lorem irure exercitation aute et. Ea id

--- a/src/feature-feedback.ts
+++ b/src/feature-feedback.ts
@@ -534,6 +534,7 @@ export class FeatureFeedback
     const submitButtonColor = css`var(--featureFeedbackSubmitButtonColor, ${blueColor})`;
     const betaButtonBorderColor = css`var(--featureFeedbackBetaButtonBorderColor, ${blueColor})`;
     const betaButtonTextColor = css`var(--featureFeedbackBetaButtonTextColor, ${blueColor})`;
+    const betaButtonBackground = css`var(--featureFeedbackBetaButtonBackground, none)`;
     const betaButtonSvgFilter = css`var(--featureFeedbackBetaButtonSvgFilter, ${darkGrayColorSvgFilter})`;
 
     const cancelButtonColor = css`var(--featureFeedbackCancelButtonColor, #515151)`;
@@ -569,6 +570,7 @@ export class FeatureFeedback
         font-weight: bold;
         font-style: italic;
         color: ${betaButtonTextColor};
+        background: ${betaButtonBackground};
         border: 1px solid ${betaButtonBorderColor};
         border-radius: 4px;
         padding: 1px 5px;

--- a/src/survey/ia-feedback-survey.ts
+++ b/src/survey/ia-feedback-survey.ts
@@ -763,6 +763,7 @@ export class IAFeedbackSurvey
     const popupBorderColor = css`var(--featureFeedbackPopupBorderColor, ${blueColor})`;
     const betaButtonBorderColor = css`var(--featureFeedbackBetaButtonBorderColor, ${blueColor})`;
     const betaButtonTextColor = css`var(--featureFeedbackBetaButtonTextColor, ${blueColor})`;
+    const betaButtonBackground = css`var(--featureFeedbackBetaButtonBackground, none)`;
     const betaButtonSvgFilter = css`var(--featureFeedbackBetaButtonSvgFilter, ${darkGrayColorSvgFilter})`;
 
     const popupBlockerColor = css`var(--featureFeedbackPopupBlockerColor, rgba(255, 255, 255, 0.3))`;
@@ -783,7 +784,7 @@ export class IAFeedbackSurvey
         border: 1px solid ${betaButtonBorderColor};
         border-radius: 4px;
         padding: 1px 5px;
-        background: none;
+        background: ${betaButtonBackground};
         -webkit-appearance: none;
         -moz-appearance: none;
         appearance: none;


### PR DESCRIPTION
There is currently no way for consumers to style the background of the Beta button, leaving the button always transparent. This PR simply adds a `--featureFeedbackBetaButtonBackground` CSS var to both feedback components to allow greater customization.